### PR TITLE
Add timezone support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ interact with the timefield in their local time, but the time would be saved int
 E.G. The user may select 14:00. They will always see the time as 14:00, but the database will save it as 13:00 as it makes 
 the BST -> GMT adjustments behind the scenes.
 
+As well as handling switching the time to and from your base app timezone, you may also pass in a timezone offset (in minutes), 
+such as the one returned by `moment().utcOffset()`. This will then adjust the time to display with the adjusted timezone
+rather than the users timezone. This is useful if you're saving the time in UTC along with the offset of the browser that 
+was used to submit it.
+
+Here you can see how we'd move UTC to BST by passing an offset of 60
+
+```php
+TimeField::make('Post start Time')->withTimezoneAdjustments(60),
+```
+
 ## Current development status
 
 - [x] Make release 0.1.0.

--- a/README.md
+++ b/README.md
@@ -53,11 +53,24 @@ You can also change the default 5 minute increments to another number:
 TimeField::make('Post start Time')->minuteIncrement(1),
 ```
 
+You can make sure that all times entered are converted back to your base app timezone (set in `config/app.php`) by calling
+the `withTimezoneAdjustments()` method on your field.
+
+```php
+TimeField::make('Post start Time')->withTimezoneAdjustments(),
+```
+
+An example of this would be when your app is set to GMT but your user is in BST (GMT+1). The user would still be able to 
+interact with the timefield in their local time, but the time would be saved into the database in GMT.
+
+E.G. The user may select 14:00. They will always see the time as 14:00, but the database will save it as 13:00 as it makes 
+the BST -> GMT adjustments behind the scenes.
+
 ## Current development status
 
 - [x] Make release 0.1.0.
 - [ ] Add minimal test scenarios.
-- [ ] Add timezone support.
+- [x] Add timezone support.
 
 ### Changelog
 

--- a/dist/js/field.js
+++ b/dist/js/field.js
@@ -60,7 +60,7 @@
 /******/ 	__webpack_require__.p = "";
 /******/
 /******/ 	// Load entry module and return exports
-/******/ 	return __webpack_require__(__webpack_require__.s = 2);
+/******/ 	return __webpack_require__(__webpack_require__.s = 3);
 /******/ })
 /************************************************************************/
 /******/ ([
@@ -174,6 +174,48 @@ module.exports = function normalizeComponent (
 
 /***/ }),
 /* 1 */
+/***/ (function(module, __webpack_exports__, __webpack_require__) {
+
+"use strict";
+var Timezones = {
+    computed: {
+        timezoneAdjustments: function timezoneAdjustments() {
+            return this.field.timezoneAdjustments || false;
+        },
+
+
+        /**
+         * Get the user's local timezone.
+         */
+        userTimezone: function userTimezone() {
+            return Nova.config.userTimezone ? Nova.config.userTimezone : moment.tz.guess();
+        }
+    },
+    methods: {
+        /**
+         * Convert the given localized date time string to the application's timezone.
+         */
+        toAppTimezone: function toAppTimezone(value) {
+            return value ? moment.tz(value, 'HH:mm', this.userTimezone).clone().tz(Nova.config.timezone).format('HH:mm') : value;
+        },
+
+        /**
+         * Convert the given application timezone date time string to the local timezone.
+         */
+        fromAppTimezone: function fromAppTimezone(value) {
+            if (!value) {
+                return value;
+            }
+
+            return moment.tz(value, 'HH:mm', Nova.config.timezone).clone().tz(this.userTimezone).format('HH:mm');
+        }
+    }
+};
+
+/* harmony default export */ __webpack_exports__["a"] = (Timezones);
+
+/***/ }),
+/* 2 */
 /***/ (function(module, exports) {
 
 /*
@@ -255,32 +297,32 @@ function toComment(sourceMap) {
 
 
 /***/ }),
-/* 2 */
-/***/ (function(module, exports, __webpack_require__) {
-
-module.exports = __webpack_require__(3);
-
-
-/***/ }),
 /* 3 */
 /***/ (function(module, exports, __webpack_require__) {
 
-Nova.booting(function (Vue, router) {
-    Vue.component('index-nova-time-field', __webpack_require__(4));
-    Vue.component('detail-nova-time-field', __webpack_require__(7));
-    Vue.component('form-nova-time-field', __webpack_require__(10));
-});
+module.exports = __webpack_require__(4);
+
 
 /***/ }),
 /* 4 */
 /***/ (function(module, exports, __webpack_require__) {
 
+Nova.booting(function (Vue, router) {
+    Vue.component('index-nova-time-field', __webpack_require__(5));
+    Vue.component('detail-nova-time-field', __webpack_require__(8));
+    Vue.component('form-nova-time-field', __webpack_require__(11));
+});
+
+/***/ }),
+/* 5 */
+/***/ (function(module, exports, __webpack_require__) {
+
 var disposed = false
 var normalizeComponent = __webpack_require__(0)
 /* script */
-var __vue_script__ = __webpack_require__(5)
+var __vue_script__ = __webpack_require__(6)
 /* template */
-var __vue_template__ = __webpack_require__(6)
+var __vue_template__ = __webpack_require__(7)
 /* template functional */
 var __vue_template_functional__ = false
 /* styles */
@@ -319,22 +361,32 @@ module.exports = Component.exports
 
 
 /***/ }),
-/* 5 */
+/* 6 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__mixins_Timezones__ = __webpack_require__(1);
 //
 //
 //
 //
 
+
+
 /* harmony default export */ __webpack_exports__["default"] = ({
-    props: ['field']
+    mixins: [__WEBPACK_IMPORTED_MODULE_0__mixins_Timezones__["a" /* default */]],
+    props: ['field'],
+
+    computed: {
+        localizedValue: function localizedValue() {
+            return this.timezoneAdjustments ? this.fromAppTimezone(this.field.value) : this.field.value;
+        }
+    }
 });
 
 /***/ }),
-/* 6 */
+/* 7 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var render = function() {
@@ -342,7 +394,7 @@ var render = function() {
   var _h = _vm.$createElement
   var _c = _vm._self._c || _h
   return _c("span", { staticClass: "whitespace-no-wrap" }, [
-    _vm._v(_vm._s(_vm.field.value))
+    _vm._v(_vm._s(_vm.localizedValue))
   ])
 }
 var staticRenderFns = []
@@ -356,15 +408,15 @@ if (false) {
 }
 
 /***/ }),
-/* 7 */
+/* 8 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var disposed = false
 var normalizeComponent = __webpack_require__(0)
 /* script */
-var __vue_script__ = __webpack_require__(8)
+var __vue_script__ = __webpack_require__(9)
 /* template */
-var __vue_template__ = __webpack_require__(9)
+var __vue_template__ = __webpack_require__(10)
 /* template functional */
 var __vue_template_functional__ = false
 /* styles */
@@ -403,29 +455,56 @@ module.exports = Component.exports
 
 
 /***/ }),
-/* 8 */
+/* 9 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__mixins_Timezones__ = __webpack_require__(1);
+//
+//
+//
+//
+//
+//
 //
 //
 //
 //
 
+
+
 /* harmony default export */ __webpack_exports__["default"] = ({
-    props: ['field']
+    mixins: [__WEBPACK_IMPORTED_MODULE_0__mixins_Timezones__["a" /* default */]],
+    props: ['field'],
+
+    computed: {
+        localizedValue: function localizedValue() {
+            return this.timezoneAdjustments ? this.fromAppTimezone(this.field.value) : this.field.value;
+        }
+    }
 });
 
 /***/ }),
-/* 9 */
+/* 10 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var render = function() {
   var _vm = this
   var _h = _vm.$createElement
   var _c = _vm._self._c || _h
-  return _c("panel-item", { attrs: { field: _vm.field } })
+  return _c(
+    "panel-item",
+    { attrs: { field: _vm.field } },
+    [
+      _c("template", { slot: "value" }, [
+        _c("p", { staticClass: "text-90" }, [
+          _vm._v("\n            " + _vm._s(_vm.localizedValue) + "\n        ")
+        ])
+      ])
+    ],
+    2
+  )
 }
 var staticRenderFns = []
 render._withStripped = true
@@ -438,15 +517,15 @@ if (false) {
 }
 
 /***/ }),
-/* 10 */
+/* 11 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var disposed = false
 var normalizeComponent = __webpack_require__(0)
 /* script */
-var __vue_script__ = __webpack_require__(11)
+var __vue_script__ = __webpack_require__(12)
 /* template */
-var __vue_template__ = __webpack_require__(25)
+var __vue_template__ = __webpack_require__(26)
 /* template functional */
 var __vue_template_functional__ = false
 /* styles */
@@ -485,15 +564,16 @@ module.exports = Component.exports
 
 
 /***/ }),
-/* 11 */
+/* 12 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__TimePicker__ = __webpack_require__(12);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__TimePicker__ = __webpack_require__(13);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0__TimePicker___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0__TimePicker__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_laravel_nova__ = __webpack_require__(24);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_laravel_nova___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_laravel_nova__);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1__mixins_Timezones__ = __webpack_require__(1);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2_laravel_nova__ = __webpack_require__(25);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_2_laravel_nova___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_2_laravel_nova__);
 //
 //
 //
@@ -516,12 +596,13 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 //
 //
 //
+
 
 
 
 
 /* harmony default export */ __webpack_exports__["default"] = ({
-    mixins: [__WEBPACK_IMPORTED_MODULE_1_laravel_nova__["HandlesValidationErrors"], __WEBPACK_IMPORTED_MODULE_1_laravel_nova__["FormField"]],
+    mixins: [__WEBPACK_IMPORTED_MODULE_2_laravel_nova__["HandlesValidationErrors"], __WEBPACK_IMPORTED_MODULE_2_laravel_nova__["FormField"], __WEBPACK_IMPORTED_MODULE_1__mixins_Timezones__["a" /* default */]],
 
     components: { TimePicker: __WEBPACK_IMPORTED_MODULE_0__TimePicker___default.a },
 
@@ -542,6 +623,22 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
             if (event.target.value === '') {
                 this.flatpickr.close();
             }
+        },
+
+
+        /**
+         * Set the initial, internal value for the field.
+         */
+        setInitialValue: function setInitialValue() {
+            this.value = this.timezoneAdjustments ? this.fromAppTimezone(this.field.value || '') : this.field.value || '';
+        },
+
+
+        /**
+         * Fill the given FormData object with the field's internal value.
+         */
+        fill: function fill(formData) {
+            formData.append(this.field.attribute, this.timezoneAdjustments ? this.toAppTimezone(this.value || '') : this.value || '');
         }
     },
 
@@ -551,19 +648,19 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 });
 
 /***/ }),
-/* 12 */
+/* 13 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var disposed = false
 function injectStyle (ssrContext) {
   if (disposed) return
-  __webpack_require__(13)
+  __webpack_require__(14)
 }
 var normalizeComponent = __webpack_require__(0)
 /* script */
-var __vue_script__ = __webpack_require__(17)
+var __vue_script__ = __webpack_require__(18)
 /* template */
-var __vue_template__ = __webpack_require__(23)
+var __vue_template__ = __webpack_require__(24)
 /* template functional */
 var __vue_template_functional__ = false
 /* styles */
@@ -602,17 +699,17 @@ module.exports = Component.exports
 
 
 /***/ }),
-/* 13 */
+/* 14 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // style-loader: Adds some css to the DOM by adding a <style> tag
 
 // load the styles
-var content = __webpack_require__(14);
+var content = __webpack_require__(15);
 if(typeof content === 'string') content = [[module.i, content, '']];
 if(content.locals) module.exports = content.locals;
 // add the styles to the DOM
-var update = __webpack_require__(15)("60262c87", content, false, {});
+var update = __webpack_require__(16)("05464087", content, false, {});
 // Hot Module Replacement
 if(false) {
  // When the styles change, update the <style> tags
@@ -628,21 +725,21 @@ if(false) {
 }
 
 /***/ }),
-/* 14 */
+/* 15 */
 /***/ (function(module, exports, __webpack_require__) {
 
-exports = module.exports = __webpack_require__(1)(false);
+exports = module.exports = __webpack_require__(2)(false);
 // imports
 
 
 // module
-exports.push([module.i, "\n.\\!cursor-not-allowed[data-v-4c69ed4e] {\r\n    cursor: not-allowed !important;\n}\r\n", ""]);
+exports.push([module.i, "\n.\\!cursor-not-allowed[data-v-4c69ed4e] {\n    cursor: not-allowed !important;\n}\n", ""]);
 
 // exports
 
 
 /***/ }),
-/* 15 */
+/* 16 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /*
@@ -661,7 +758,7 @@ if (typeof DEBUG !== 'undefined' && DEBUG) {
   ) }
 }
 
-var listToStyles = __webpack_require__(16)
+var listToStyles = __webpack_require__(17)
 
 /*
 type StyleObject = {
@@ -870,7 +967,7 @@ function applyToTag (styleElement, obj) {
 
 
 /***/ }),
-/* 16 */
+/* 17 */
 /***/ (function(module, exports) {
 
 /**
@@ -903,14 +1000,14 @@ module.exports = function listToStyles (parentId, list) {
 
 
 /***/ }),
-/* 17 */
+/* 18 */
 /***/ (function(module, __webpack_exports__, __webpack_require__) {
 
 "use strict";
 Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(18);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr__ = __webpack_require__(19);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_0_flatpickr___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_0_flatpickr__);
-/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_flatpickr_dist_themes_airbnb_css__ = __webpack_require__(19);
+/* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_flatpickr_dist_themes_airbnb_css__ = __webpack_require__(20);
 /* harmony import */ var __WEBPACK_IMPORTED_MODULE_1_flatpickr_dist_themes_airbnb_css___default = __webpack_require__.n(__WEBPACK_IMPORTED_MODULE_1_flatpickr_dist_themes_airbnb_css__);
 
 
@@ -975,7 +1072,7 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 });
 
 /***/ }),
-/* 18 */
+/* 19 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /* flatpickr v4.6.3, @license MIT */
@@ -3586,13 +3683,13 @@ Object.defineProperty(__webpack_exports__, "__esModule", { value: true });
 
 
 /***/ }),
-/* 19 */
+/* 20 */
 /***/ (function(module, exports, __webpack_require__) {
 
 // style-loader: Adds some css to the DOM by adding a <style> tag
 
 // load the styles
-var content = __webpack_require__(20);
+var content = __webpack_require__(21);
 if(typeof content === 'string') content = [[module.i, content, '']];
 // Prepare cssTransformation
 var transform;
@@ -3600,7 +3697,7 @@ var transform;
 var options = {}
 options.transform = transform
 // add the styles to the DOM
-var update = __webpack_require__(21)(content, options);
+var update = __webpack_require__(22)(content, options);
 if(content.locals) module.exports = content.locals;
 // Hot Module Replacement
 if(false) {
@@ -3617,10 +3714,10 @@ if(false) {
 }
 
 /***/ }),
-/* 20 */
+/* 21 */
 /***/ (function(module, exports, __webpack_require__) {
 
-exports = module.exports = __webpack_require__(1)(false);
+exports = module.exports = __webpack_require__(2)(false);
 // imports
 
 
@@ -3631,7 +3728,7 @@ exports.push([module.i, ".flatpickr-calendar {\n  background: transparent;\n  op
 
 
 /***/ }),
-/* 21 */
+/* 22 */
 /***/ (function(module, exports, __webpack_require__) {
 
 /*
@@ -3677,7 +3774,7 @@ var singleton = null;
 var	singletonCounter = 0;
 var	stylesInsertedAtTop = [];
 
-var	fixUrls = __webpack_require__(22);
+var	fixUrls = __webpack_require__(23);
 
 module.exports = function(list, options) {
 	if (typeof DEBUG !== "undefined" && DEBUG) {
@@ -3990,7 +4087,7 @@ function updateLink (link, options, obj) {
 
 
 /***/ }),
-/* 22 */
+/* 23 */
 /***/ (function(module, exports) {
 
 
@@ -4085,7 +4182,7 @@ module.exports = function (css) {
 
 
 /***/ }),
-/* 23 */
+/* 24 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var render = function() {
@@ -4131,7 +4228,7 @@ if (false) {
 }
 
 /***/ }),
-/* 24 */
+/* 25 */
 /***/ (function(module, exports, __webpack_require__) {
 
 (function webpackUniversalModuleDefinition(root, factory) {
@@ -31537,7 +31634,7 @@ if (hadRuntime) {
 });
 
 /***/ }),
-/* 25 */
+/* 26 */
 /***/ (function(module, exports, __webpack_require__) {
 
 var render = function() {

--- a/resources/js/components/DetailField.vue
+++ b/resources/js/components/DetailField.vue
@@ -1,9 +1,26 @@
 <template>
-    <panel-item :field="field" />
+    <panel-item :field="field">
+        <template slot="value">
+            <p class="text-90">
+                {{ localizedValue }}
+            </p>
+        </template>
+    </panel-item>
 </template>
 
 <script>
+import Timezones from "../mixins/Timezones";
+
 export default {
+    mixins: [Timezones],
     props: ['field'],
+
+    computed: {
+        localizedValue() {
+            return this.timezoneAdjustments ?
+            this.fromAppTimezone(this.field.value) :
+            this.field.value
+        }
+    },
 }
 </script>

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -22,10 +22,11 @@
 
 <script>
 import TimePicker from './../TimePicker'
+import Timezones from './../mixins/Timezones'
 import { FormField, HandlesValidationErrors } from 'laravel-nova'
 
 export default {
-    mixins: [HandlesValidationErrors, FormField],
+    mixins: [HandlesValidationErrors, FormField, Timezones],
 
     components: { TimePicker },
 
@@ -41,61 +42,32 @@ export default {
         minuteIncrement() {
             return this.field.minuteIncrement || 5;
         },
-
-        /**
-         * Get the user's local timezone.
-         */
-        userTimezone: function userTimezone() {
-            return Nova.config.userTimezone ? Nova.config.userTimezone : moment.tz.guess();
-        },
-
-        timezoneAdjustments() {
-            return this.field.timezoneAdjustments || false;
-        },
     },
 
     methods: {
-       onClear(event) {
-           if(event.target.value === '') {
-             this.flatpickr.close();
-           }
-       },
+        onClear(event) {
+            if(event.target.value === '') {
+                this.flatpickr.close();
+            }
+        },
 
         /**
          * Set the initial, internal value for the field.
          */
         setInitialValue() {
-          this.value = this.timezoneAdjustments ?
-            this.fromAppTimezone(this.field.value || '') :
-            this.field.value || ''
+            this.value = this.timezoneAdjustments ?
+                this.fromAppTimezone(this.field.value || '') :
+                this.field.value || ''
         },
 
         /**
          * Fill the given FormData object with the field's internal value.
          */
         fill(formData) {
-          formData.append(this.field.attribute, this.timezoneAdjustments ?
-            this.toAppTimezone(this.value || '') :
-            this.value || ''
-          )
-        },
-
-        /**
-         * Convert the given localized date time string to the application's timezone.
-         */
-        toAppTimezone: function toAppTimezone(value) {
-            return value ? moment.tz(value, 'HH:mm', this.userTimezone).clone().tz(Nova.config.timezone).format('HH:mm') : value;
-        },
-
-        /**
-         * Convert the given application timezone date time string to the local timezone.
-         */
-        fromAppTimezone: function fromAppTimezone(value) {
-            if (!value) {
-                return value;
-            }
-
-            return moment.tz(value, 'HH:mm', Nova.config.timezone).clone().tz(this.userTimezone).format('HH:mm');
+            formData.append(this.field.attribute, this.timezoneAdjustments ?
+                  this.toAppTimezone(this.value || '') :
+                  this.value || ''
+            )
         },
     },
 

--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -48,6 +48,10 @@ export default {
         userTimezone: function userTimezone() {
             return Nova.config.userTimezone ? Nova.config.userTimezone : moment.tz.guess();
         },
+
+        timezoneAdjustments() {
+            return this.field.timezoneAdjustments || false;
+        },
     },
 
     methods: {
@@ -61,14 +65,19 @@ export default {
          * Set the initial, internal value for the field.
          */
         setInitialValue() {
-            this.value = this.fromAppTimezone(this.field.value || '')
+          this.value = this.timezoneAdjustments ?
+            this.fromAppTimezone(this.field.value || '') :
+            this.field.value || ''
         },
 
         /**
          * Fill the given FormData object with the field's internal value.
          */
         fill(formData) {
-            formData.append(this.field.attribute, this.toAppTimezone(this.value) || '')
+          formData.append(this.field.attribute, this.timezoneAdjustments ?
+            this.toAppTimezone(this.value || '') :
+            this.value || ''
+          )
         },
 
         /**

--- a/resources/js/components/IndexField.vue
+++ b/resources/js/components/IndexField.vue
@@ -1,9 +1,20 @@
 <template>
-    <span class="whitespace-no-wrap">{{ field.value }}</span>
+    <span class="whitespace-no-wrap">{{ localizedValue }}</span>
 </template>
 
 <script>
+import Timezones from "../mixins/Timezones";
+
 export default {
+    mixins: [Timezones],
     props: ['field'],
+
+    computed: {
+        localizedValue() {
+            return this.timezoneAdjustments ?
+                this.fromAppTimezone(this.field.value) :
+            this.field.value
+        }
+    },
 }
 </script>

--- a/resources/js/mixins/Timezones.js
+++ b/resources/js/mixins/Timezones.js
@@ -27,6 +27,13 @@ const Timezones = {
                 return value;
             }
 
+            if (this.field.timezoneAdjustment) {
+                return moment.utc(value, 'HH:mm')
+                    .clone()
+                    .add(this.field.timezoneAdjustment, 'minutes')
+                    .format('HH:mm');
+            }
+
             return moment.tz(value, 'HH:mm', Nova.config.timezone).clone().tz(this.userTimezone).format('HH:mm');
         },
     }

--- a/resources/js/mixins/Timezones.js
+++ b/resources/js/mixins/Timezones.js
@@ -1,0 +1,35 @@
+const Timezones = {
+    computed: {
+        timezoneAdjustments() {
+            return this.field.timezoneAdjustments || false;
+        },
+
+        /**
+         * Get the user's local timezone.
+         */
+        userTimezone: function userTimezone() {
+            return Nova.config.userTimezone ? Nova.config.userTimezone : moment.tz.guess();
+        },
+    },
+    methods: {
+        /**
+         * Convert the given localized date time string to the application's timezone.
+         */
+        toAppTimezone: function toAppTimezone(value) {
+            return value ? moment.tz(value, 'HH:mm', this.userTimezone).clone().tz(Nova.config.timezone).format('HH:mm') : value;
+        },
+
+        /**
+         * Convert the given application timezone date time string to the local timezone.
+         */
+        fromAppTimezone: function fromAppTimezone(value) {
+            if (!value) {
+                return value;
+            }
+
+            return moment.tz(value, 'HH:mm', Nova.config.timezone).clone().tz(this.userTimezone).format('HH:mm');
+        },
+    }
+}
+
+export default Timezones

--- a/src/TimeField.php
+++ b/src/TimeField.php
@@ -50,9 +50,16 @@ class TimeField extends Field
         return $this->withMeta(['twelveHourTime' => true]);
     }
 
-    public function withTimezoneAdjustments()
+    /**
+     * @param null|string $adjustment The adjustment to be applied to the date from the database.
+     * @return TimeField
+     */
+    public function withTimezoneAdjustments($adjustment = null)
     {
-        return $this->withMeta(['timezoneAdjustments' => true]);
+        return $this->withMeta([
+            'timezoneAdjustments' => true,
+            'timezoneAdjustment' => $adjustment,
+        ]);
     }
 
     /**

--- a/src/TimeField.php
+++ b/src/TimeField.php
@@ -52,13 +52,14 @@ class TimeField extends Field
 
     /**
      * @param null|string $adjustment The adjustment to be applied to the date from the database.
+     *
      * @return TimeField
      */
     public function withTimezoneAdjustments($adjustment = null)
     {
         return $this->withMeta([
             'timezoneAdjustments' => true,
-            'timezoneAdjustment' => $adjustment,
+            'timezoneAdjustment'  => $adjustment,
         ]);
     }
 

--- a/src/TimeField.php
+++ b/src/TimeField.php
@@ -50,6 +50,11 @@ class TimeField extends Field
         return $this->withMeta(['twelveHourTime' => true]);
     }
 
+    public function withTimezoneAdjustments()
+    {
+        return $this->withMeta(['timezoneAdjustments' => true]);
+    }
+
     /**
      * Hydrate the given attribute on the model based on the incoming request.
      *


### PR DESCRIPTION
Hi 👋  

Thanks for your work on this field.
We're using this in a system and ran into a scenario where we need to be able to convert all of our dates back to our application timezone (UTC). This PR offers my changes back to the main repo and the community.

It works in the following way:

When the field is initially loaded and if `timezoneAdjustments` has been set to true via the `SpecialOpeningTime::withTimezoneAdjustments()` method, the value will be converted from the application time (set in `config/app.php`) to the users local time. The user can then interact with the field in their local time, as they would usually. On save, the time is then converted back into the application time for saving in the database.

This follows the same way that the core Nova `DateTimeField` works.

It can be used in the following way:

```php
TimeField::make('Post start Time')->withTimezoneAdjustments(),
```

## New method on the `SpecialOpeningTime` class

There's a new method on this class that allows the developer to toggle this functionality. If they can the field with the `withTimezoneAdjustments()` method, timezone adjustments will be taken into account otherwise, it will handle the field as it did before. This makes sure that no backwards compatibility is broken 🎉 

## New methods on `FormField.vue`

### `setInitialValue`
This overwrites the method set in the `FormField` mixin. It's used to set an initial value on the field when it's loaded. If `timezoneAdjustments` is set to `true`, it now runs `fromAppTimezone` on the value before setting it against the field.

### `fill`
This also overwrites the method set in the `FormField` mixin. It's used to fill the FormData object before the fields are saved. If `timezoneAdjustments` is set to `true`, this now runs the value through `toAppTimezone` in order to convert the value to application time before saving.

## New mixin `Timezones.js`

### `userTimezone`
This property pulls the user's local timezone from the Nova config. If it can't find it there, it will fall back to trying to guess it using Moment's [guess](https://momentjs.com/timezone/docs/#/using-timezones/guessing-user-timezone/) functionality.

### `timezoneAdjustments`
This property is generated from the options passed to the field and is used to check if timezone adjustments should happen or not.

### `toAppTimezone`
This method uses Moment to convert the user-selected time, into the local app time. It parses the selected time using Moment.tz using the `userTimezone` computed property and converts it to the app timezone that's set in `config/app.php`.

### `fromAppTimezone`
This does this opposite of the above. It takes the time, in the app timezone that's set in `config/app.php` and converts it into the user's timezone using the `userTimezone` computed property.