### PR TITLE
Fix empty value submittion

### DIFF
--- a/src/TimeField.php
+++ b/src/TimeField.php
@@ -81,7 +81,7 @@ class TimeField extends Field
     ) {
         if ($request->exists($requestAttribute)) {
             $sentData = $request[$requestAttribute];
-            if ($this->nullable && $sentData === null) {
+            if ($this->nullable && in_array($sentData, [null, ''])) {
                 $model->{$attribute} = null;
             } else {
                 $validatedFormat = $this->validatedTimeFormat($sentData);


### PR DESCRIPTION
Leaving value empty together with ->nullable() still throws "The field must contain a valid time." exception.
That's the fix for that.